### PR TITLE
Add support for Consul tags

### DIFF
--- a/include/rabbit_peer_discovery_consul.hrl
+++ b/include/rabbit_peer_discovery_consul.hrl
@@ -70,6 +70,11 @@
                                                    env_variable  = "CONSUL_SVC_TTL",
                                                    default_value = 30
                                                   },
+          consul_svc_tags                    => #peer_discovery_config_entry_meta{
+                                                   type          = list,
+                                                   env_variable  = "CONSUL_SVC_TAGS",
+                                                   default_value = []
+                                                  },
           consul_deregister_after            => #peer_discovery_config_entry_meta{
                                                    type          = integer,
                                                    env_variable  = "CONSUL_DEREGISTER_AFTER",


### PR DESCRIPTION
Add support for Consul tags

Add support for Consul 1.x.x which enforces HTTP verbs

Pass consul token as a header

 The recommended way to pass consul tokens is now using headers,
 header support was introduced in consul version 0.6.0.

 https://www.consul.io/api/index.html#authentication

 This change is not compartible with consul versions < 0.6.0