### PR TITLE
Configure HTTP client proxy at init step

### DIFF
--- a/src/rabbit_peer_discovery_consul.erl
+++ b/src/rabbit_peer_discovery_consul.erl
@@ -23,7 +23,7 @@
 -include("rabbit_peer_discovery_consul.hrl").
 
 -export([list_nodes/0, supports_registration/0, register/0, unregister/0,
-         post_registration/0, lock/1, unlock/1]).
+         post_registration/0, lock/1, unlock/1, init/0]).
 -export([send_health_check_pass/0]).
 -export([session_ttl_update_callback/1]).
 %% useful for debugging from the REPL with RABBITMQ_ALLOW_INPUT
@@ -43,6 +43,14 @@
 %%
 %% API
 %%
+
+init() ->
+    rabbit_log:debug("Peer discovery Consul: initialising..."),
+    ok = application:ensure_started(inets),
+    %% we cannot start this plugin yet since it depends on the rabbit app,
+    %% which is in the process of being started by the time this function is called
+    application:load(rabbitmq_peer_discovery_common),
+    rabbit_peer_discovery_httpc:maybe_configure_proxy().
 
 -spec list_nodes() -> {ok, {Nodes :: list(), NodeType :: rabbit_types:node_type()}} | {error, Reason :: string()}.
 


### PR DESCRIPTION
Part of rabbitmq/rabbitmq-peer-discovery-common#5.

[#153615554]