### PR TITLE
Make it possible to use NIC for service name calculation when svc_addr_auto is set to true

### DIFF
--- a/src/rabbit_peer_discovery_consul.erl
+++ b/src/rabbit_peer_discovery_consul.erl
@@ -385,8 +385,15 @@ service_address(_, true, "undefined", FromNodename) ->
   rabbit_peer_discovery_util:node_hostname(FromNodename);
 service_address(Value, false, "undefined", _) ->
   Value;
-service_address(_, false, NIC, _) ->
+service_address(_, true, NIC, _) ->
   %% TODO: support IPv6
+  {ok, Addr} = rabbit_peer_discovery_util:nic_ipv4(NIC),
+  Addr;
+%% this combination makes no sense but this is what rabbitmq-autocluster
+%% and this plugin have been allowing for a couple of years, so we keep
+%% this clause around for backwards compatibility.
+%% See rabbitmq/rabbitmq-peer-discovery-consul#12 for details.
+service_address(_, false, NIC, _) ->
   {ok, Addr} = rabbit_peer_discovery_util:nic_ipv4(NIC),
   Addr.
 


### PR DESCRIPTION
The "auto = false but please compute using NIC" combination makes no sense and likely was originally introduced into rabbitmq-autocluster by mistake. We inherited it. So we now support both `auto` values for backwards compatibility.

Per discussion with @dcorbacho.

Closes #12.

[#158627010]