### PR TITLE
Alias cluster_formation.consul.lock_timeout to cluster_formation.consul.lock_wait_time

### DIFF
--- a/priv/schema/rabbitmq_peer_discovery_consul.schema
+++ b/priv/schema/rabbitmq_peer_discovery_consul.schema
@@ -252,16 +252,26 @@ fun(Conf) ->
     end
 end}.
 
-%% lock timeout
+%% lock acquisition timeout
+
+{mapping, "cluster_formation.consul.lock_wait_time", "rabbit.cluster_formation.peer_discovery_consul.lock_wait_time", [
+    {datatype, integer}, {validators, ["non_negative_integer"]}
+]}.
 
 {mapping, "cluster_formation.consul.lock_timeout", "rabbit.cluster_formation.peer_discovery_consul.lock_wait_time", [
     {datatype, integer}, {validators, ["non_negative_integer"]}
 ]}.
 
+%% an alias for lock acquisition timeout to be consistent with the etcd backend
+
 {translation, "rabbit.cluster_formation.peer_discovery_consul.lock_wait_time",
 fun(Conf) ->
     case cuttlefish:conf_get("cluster_formation.consul.lock_timeout", Conf, undefined) of
-        undefined -> cuttlefish:unset();
-        Value     -> Value
+        undefined ->
+            case cuttlefish:conf_get("cluster_formation.consul.lock_wait_time", Conf, undefined) of
+                    undefined -> cuttlefish:unset();
+                    Value     -> Value
+                end;
+        Value -> Value
     end
 end}.

--- a/test/config_schema_SUITE_data/rabbitmq_peer_discovery_consul.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_peer_discovery_consul.snippets
@@ -181,8 +181,20 @@
  [rabbitmq_peer_discovery_consul]}
 
 
+ %% lock acquisition timeout
+
  , {consul_lock_timeout,
   "cluster_formation.consul.lock_timeout = 60",
+  [{rabbit, [{cluster_formation, [
+                                  {peer_discovery_consul, [
+                                                           {lock_wait_time, 60}
+                                                          ]}
+                                 ]}]}],
+ [rabbitmq_peer_discovery_consul]}
+
+ %% alias for consistency with etcd
+ , {consul_lock_wait_time,
+  "cluster_formation.consul.lock_wait_time = 60",
   [{rabbit, [{cluster_formation, [
                                   {peer_discovery_consul, [
                                                            {lock_wait_time, 60}


### PR DESCRIPTION
For consistency with the name rabbitmq-peer-discovery-etcd uses. That backend
will be updated to support both keys as well.

References #3, #16, #17.