### PR TITLE
Allow service metadata to be defined

### DIFF
--- a/include/rabbit_peer_discovery_consul.hrl
+++ b/include/rabbit_peer_discovery_consul.hrl
@@ -75,6 +75,10 @@
                                                    env_variable  = "CONSUL_SVC_TAGS",
                                                    default_value = []
                                                   },
+          consul_svc_meta                    => #peer_discovery_config_entry_meta{
+                                                   type          = list,
+                                                   default_value = []
+                                                  },
           consul_deregister_after            => #peer_discovery_config_entry_meta{
                                                    type          = integer,
                                                    env_variable  = "CONSUL_DEREGISTER_AFTER",

--- a/priv/schema/rabbitmq_peer_discovery_consul.schema
+++ b/priv/schema/rabbitmq_peer_discovery_consul.schema
@@ -258,6 +258,26 @@ fun(Conf) ->
     end
 end}.
 
+%% service metadata
+
+{mapping, "cluster_formation.consul.svc_meta", "rabbit.cluster_formation.peer_discovery_consul.consul_svc_meta", [
+    {datatype, {enum, [none]}}
+]}.
+
+{mapping, "cluster_formation.consul.svc_meta.$name", "rabbit.cluster_formation.peer_discovery_consul.consul_svc_meta", [
+    {datatype, string}
+]}.
+
+{translation, "rabbit.cluster_formation.peer_discovery_consul.consul_svc_meta",
+fun(Conf) ->
+    case cuttlefish:conf_get("cluster_formation.consul.svc_meta", Conf, undefined) of
+        none -> [];
+        _    ->
+          Pairs = cuttlefish_variable:filter_by_prefix("cluster_formation.consul.svc_meta", Conf),
+          [{list_to_binary(lists:last(Segments)), list_to_binary(V)} || {Segments, V} <- Pairs]
+    end
+end}.
+
 %% lock key prefix
 
 {mapping, "cluster_formation.consul.lock_prefix", "rabbit.cluster_formation.peer_discovery_consul.consul_lock_prefix", [

--- a/src/rabbit_peer_discovery_consul.erl
+++ b/src/rabbit_peer_discovery_consul.erl
@@ -371,7 +371,7 @@ registration_body_maybe_add_meta(Payload, "default", []) ->
   Payload;
 registration_body_maybe_add_meta(Payload, "default", Meta) ->
   lists:append(Payload, [{<<"meta">>, Meta}]);
-registration_body_maybe_add_meta(Payload, ClusterName, []) ->
+registration_body_maybe_add_meta(Payload, _ClusterName, []) ->
   Payload;
 registration_body_maybe_add_meta(Payload, ClusterName, Meta) ->
   Merged = maps:to_list(maps:merge(#{<<"cluster">> => rabbit_data_coercion:to_binary(ClusterName)}, maps:from_list(Meta))),

--- a/src/rabbit_peer_discovery_consul.erl
+++ b/src/rabbit_peer_discovery_consul.erl
@@ -567,7 +567,7 @@ consul_session_create(Query, Headers, Body) ->
 %%--------------------------------------------------------------------
 -spec serialize_json_body(term()) -> {ok, Payload :: binary()} | {error, atom()}.
 serialize_json_body([]) -> {ok, []};
-serialize_json_body(Payload) ->©p
+serialize_json_body(Payload) ->
     case rabbit_json:try_encode(Payload) of
         {ok, Body} -> {ok, Body};
         {error, Reason} -> {error, Reason}

--- a/src/rabbit_peer_discovery_consul.erl
+++ b/src/rabbit_peer_discovery_consul.erl
@@ -249,6 +249,7 @@ list_nodes_query_args(Value, Warn) ->
 -spec registration_body() -> {ok, Body :: binary()} | {error, atom()}.
 registration_body() ->
   Payload = build_registration_body(),
+  rabbit_log:debug("Payload for Consul registration: ~p", [Payload]),
   registration_body(rabbit_json:try_encode(Payload)).
 
 -spec registration_body(Response :: {ok, Body :: string()} |
@@ -269,7 +270,8 @@ build_registration_body() ->
   Payload3 = registration_body_maybe_add_address(Payload2),
   Payload4 = registration_body_add_port(Payload3),
   Payload5 = registration_body_maybe_add_check(Payload4),
-  registration_body_maybe_add_tag(Payload5).
+  Payload6 = registration_body_maybe_add_tag(Payload5),
+  registration_body_maybe_add_meta(Payload6).
 
 -spec registration_body_add_id() -> list().
 registration_body_add_id() ->
@@ -354,6 +356,27 @@ registration_body_maybe_add_tag(Payload, Cluster, []) ->
   lists:append(Payload, [{'Tags', [rabbit_data_coercion:to_atom(Cluster)]}]);
 registration_body_maybe_add_tag(Payload, Cluster, Tags) ->
   lists:append(Payload, [{'Tags', [rabbit_data_coercion:to_atom(Cluster)] ++ [rabbit_data_coercion:to_atom(X) || X <- Tags]}]).
+
+
+-spec registration_body_maybe_add_meta(Payload :: list()) -> list().
+registration_body_maybe_add_meta(Payload) ->
+  M = ?CONFIG_MODULE:config_map(?BACKEND_CONFIG_KEY),
+  ClusterName = get_config_key(cluster_name, M),
+  Meta = ?UTIL_MODULE:as_list(get_config_key(consul_svc_meta, M)),
+  registration_body_maybe_add_meta(Payload, ClusterName, Meta).
+
+-spec registration_body_maybe_add_meta(Payload :: list(),
+                                       ClusterName :: string(),
+                                       Meta :: list()) -> list().
+registration_body_maybe_add_meta(Payload, "default", []) ->
+  Payload;
+registration_body_maybe_add_meta(Payload, "default", Meta) ->
+  lists:append(Payload, [{<<"meta">>, Meta}]);
+registration_body_maybe_add_meta(Payload, ClusterName, []) ->
+  Payload;
+registration_body_maybe_add_meta(Payload, ClusterName, Meta) ->
+  Merged = maps:to_list(maps:merge(#{<<"cluster">> => rabbit_data_coercion:to_binary(ClusterName)}, maps:from_list(Meta))),
+  lists:append(Payload, [{<<"meta">>, Merged}]).
 
 
 -spec validate_addr_parameters(false | true, false | true) -> false | true.
@@ -517,7 +540,7 @@ create_session(Name, TTL) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec consul_session_create(Query, Headers, Body) -> {ok, term()} | {error, Reason::string()} when
-      Query :: [autocluster_httpc:query_component()],
+      Query :: list(),
       Headers :: [{string(), string()}],
       Body :: term().
 consul_session_create(Query, Headers, Body) ->
@@ -546,6 +569,7 @@ consul_session_create(Query, Headers, Body) ->
 -spec serialize_json_body(term()) -> {ok, Payload :: binary()} | {error, atom()}.
 serialize_json_body([]) -> {ok, []};
 serialize_json_body(Payload) ->
+    rabbit_log:debug("JSON body to serialize: ~p", [Payload]),
     case rabbit_json:try_encode(Payload) of
         {ok, Body} -> {ok, Body};
         {error, Reason} -> {error, Reason}

--- a/src/rabbit_peer_discovery_consul.erl
+++ b/src/rabbit_peer_discovery_consul.erl
@@ -249,7 +249,6 @@ list_nodes_query_args(Value, Warn) ->
 -spec registration_body() -> {ok, Body :: binary()} | {error, atom()}.
 registration_body() ->
   Payload = build_registration_body(),
-  rabbit_log:debug("Payload for Consul registration: ~p", [Payload]),
   registration_body(rabbit_json:try_encode(Payload)).
 
 -spec registration_body(Response :: {ok, Body :: string()} |
@@ -568,8 +567,7 @@ consul_session_create(Query, Headers, Body) ->
 %%--------------------------------------------------------------------
 -spec serialize_json_body(term()) -> {ok, Payload :: binary()} | {error, atom()}.
 serialize_json_body([]) -> {ok, []};
-serialize_json_body(Payload) ->
-    rabbit_log:debug("JSON body to serialize: ~p", [Payload]),
+serialize_json_body(Payload) ->©p
     case rabbit_json:try_encode(Payload) of
         {ok, Body} -> {ok, Body};
         {error, Reason} -> {error, Reason}

--- a/test/config_schema_SUITE_data/rabbitmq_peer_discovery_consul.snippets
+++ b/test/config_schema_SUITE_data/rabbitmq_peer_discovery_consul.snippets
@@ -233,6 +233,39 @@
                                  ]}]}],
  [rabbitmq_peer_discovery_consul]}
 
+
+ , {consul_service_meta,
+  "cluster_formation.consul.svc_meta.owner = an-owner
+   cluster_formation.consul.svc_meta.env = qa",
+  [{rabbit, [{cluster_formation, [
+                                  {peer_discovery_consul, [
+                                                           {consul_svc_meta, [{<<"owner">>, <<"an-owner">>},
+                                                                              {<<"env">>,   <<"qa">>}]}
+                                                          ]}
+                                 ]}]}],
+ [rabbitmq_peer_discovery_consul]}
+
+ , {consul_service_meta_set_to_none,
+  "cluster_formation.consul.svc_meta = none",
+  [{rabbit, [{cluster_formation, [
+                                  {peer_discovery_consul, [
+                                                           {consul_svc_meta, []}
+                                                          ]}
+                                 ]}]}],
+ [rabbitmq_peer_discovery_consul]}
+
+ , {consul_service_meta_with_spaces,
+  "cluster_formation.consul.svc_meta.owner = an owner
+   cluster_formation.consul.svc_meta.env = qa",
+  [{rabbit, [{cluster_formation, [
+                                  {peer_discovery_consul, [
+                                                           {consul_svc_meta, [{<<"owner">>, <<"an owner">>},
+                                                                              {<<"env">>,   <<"qa">>}]}
+                                                          ]}
+                                 ]}]}],
+ [rabbitmq_peer_discovery_consul]}
+
+
  , {all_values_absent,
   "",
   [],


### PR DESCRIPTION
## Proposed Changes

An example config file snippet:

``` ini
cluster_formation.consul.svc_meta.key1 = value1
cluster_formation.consul.svc_meta.key2 = value2
```

Depends on https://github.com/rabbitmq/rabbitmq-peer-discovery-common/commit/6cd232c9f0db8bd79c7c217bf89995a4933253cd.

Documentation PR: https://github.com/rabbitmq/rabbitmq-website/pull/879.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue …)
- [x] New feature (non-breaking change which adds functionality, #34)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #34.
